### PR TITLE
Add unread_count to UserConversation

### DIFF
--- a/js-sdk/demo/bundle.js
+++ b/js-sdk/demo/bundle.js
@@ -50,9 +50,12 @@ function SkygearChatContainer() {
   };
 
   this.getConversation = function(conversation_id) {
-    const query = new skygear.Query(Conversation);
-    query.equalTo('_id', conversation_id);
-    return skygear.publicDB.query(query).then(function(records) {
+    const query = new skygear.Query(UserConversation);
+    query.equalTo('user', skygear.currentUser.id);
+    query.equalTo('conversation', conversation_id);
+    query.transientInclude('user');
+    query.transientInclude('conversation');
+    return skygear.privateDB.query(query).then(function(records) {
       if (records.length > 0) {
         return records[0];
       }
@@ -158,18 +161,16 @@ function SkygearChatContainer() {
   };
 
   this.markAsLastMessageRead = function(conversation_id, message_id) {
-    return _getOrCreateLastMessageRead(conversation_id).then(
-      function(record) {
-        record.message_id = message_id;
-        return skygear.privateDB.save(record);
-      });
+    return _getUserConversation(conversation_id).then(function (uc) {
+      uc.last_read_message = new skygear.Reference('message/' + message_id);
+      return skygear.privateDB.save(uc);
+    });
   };
 
   this.getUnreadMessageCount = function(conversation_id) {
-    return skygear.lambda('chat:get_unread_message_count', [conversation_id])
-      .then(function(data) {
-        return data.count;
-      });
+    return _getUserConversation(conversation_id).then(function (uc) {
+      return uc.unread_count;
+    });
   };
 
   this.subscribe = function(handler) {
@@ -201,17 +202,16 @@ function SkygearChatContainer() {
     });
   }
 
-  function _getOrCreateLastMessageRead(conversation_id) {
-    const query = new skygear.Query(LastMessageRead);
-    query.equalTo('conversation_id', conversation_id);
-    query.limit = 1;
-    return skygear.privateDB.query(query).then(function(records) {
+  function _getUserConversation(conversation_id) {
+    const ucQuery = new skygear.Query(UserConversation);
+    ucQuery.equalTo('user', skygear.currentUser.id);
+    ucQuery.equalTo('conversation', conversation_id);
+    ucQuery.limit = 1;
+    return skygear.privateDB.query(ucQuery).then(function(records) {
       if (records.length > 0) {
         return records[0];
       }
-      const record = new LastMessageRead();
-      record.conversation_id = conversation_id;
-      return skygear.privateDB.save(record);
+      throw new Error('No UserConversation found');
     });
   }
 }

--- a/js-sdk/demo/demo.js
+++ b/js-sdk/demo/demo.js
@@ -79,7 +79,15 @@ class Demo {
     });
   }
 
-  fetchConversationTo(el) {
+  fetchConversationTo(conversationID, el) {
+    return this.plugin.getConversation(conversationID).then(function (result) {
+      var ul = $(el);
+      console.log(result);
+      ul.textContent = JSON.stringify(result);
+    });
+  }
+
+  fetchConversationsTo(el) {
     return this.plugin.getConversations().then(function (result) {
       var ul = $(el);
       ul.innerHTML = "";
@@ -97,6 +105,36 @@ class Demo {
       console.log(result);
       this.directConversationEl.textContent = result._id;
     }.bind(this));
+  }
+
+  createConversation(user1, user2, user3) {
+    return this.plugin.createConversation(
+        [user1, user2, user3],
+        null,
+        'From Demo'
+      ).then(function (result) {
+      console.log(result);
+      this.groupConversationEl.textContent = result._id;
+    }.bind(this));
+  }
+
+  addParticipant(conversationID, userID) {
+    return this.plugin.addParticipants(conversationID, [userID]).then(function (result) {
+      console.log(result);
+    });
+  }
+
+  removeParticipant(conversationID, userID) {
+    return this.plugin.removeParticipants(conversationID, [userID]).then(function (result) {
+      console.log(result);
+    });
+  }
+
+  markAsLastRead(conversationID, messageID, el) {
+    return this.plugin.markAsLastMessageRead(conversationID, messageID).then(function (result) {
+      var rEl = $(el);
+      rEl.textContent = JSON.stringify(result);
+    });
   }
 
   getMessagesTo(conversationID, limit, beforeTime, el) {

--- a/js-sdk/demo/index.html
+++ b/js-sdk/demo/index.html
@@ -98,7 +98,7 @@
     <ul id="conversation">
     </ul>
     <p><button
-      onclick="demo.fetchConversationTo('conversation');"
+      onclick="demo.fetchConversationsTo('conversation');"
     >Fetch Converstion</button></p>
     <hr/>
     <h3>Go to converation</h3>

--- a/js-sdk/demo/message.html
+++ b/js-sdk/demo/message.html
@@ -37,6 +37,12 @@
       <label>Conversation ID</label>
       <input id="conversation-id" type="text" />
     </p>
+    <p><button
+      onclick="demo.fetchConversationTo(inputVal('conversation-id'),
+      'conversation-detail');"
+    >Fetch User Conversation Details
+    </button></p>
+    <p id="conversation-detail"><p>
     <hr/>
 
     <h3>Participant</h3>
@@ -65,6 +71,19 @@
       'messages');"
     >Fetch messages
     </button></p>
+    <hr/>
+    <h3>Mark as last read</h3>
+    <p>
+      <label>Last Read Message ID</label>
+      <input id="last-read" type="text" />
+    </p>
+    <p><button
+      onclick="demo.markAsLastRead(inputVal('conversation-id'),
+      inputVal('last-read'),
+      'last-read-result');"
+    >Mark this as last read message
+    </button></p>
+    <p id="last-read-result"></p>
     <hr/>
     <p>
       <label>Body</label><br />

--- a/plugin/message.py
+++ b/plugin/message.py
@@ -28,40 +28,16 @@ def handle_message_after_save(record, original_record, conn):
     for p_id in conversation['participant_ids']:
         _publish_event(
             p_id, "message", "create", record)
-
-
-@skygear.before_save("last_message_read", async=False)
-def handle_last_message_read_before_save(record, original_record, conn):
-    new_id = record.get('message_id')
-    if new_id is None:
-        return
-
-    old_id = original_record and original_record.get('message_id')
-    conversation_id = record['conversation_id']
-
-    cur = conn.execute('''
-        SELECT _id, _created_at
-        FROM %(schema_name)s.message
-        WHERE (_id = %(new_id)s OR _id = %(old_id)s)
-        AND conversation_id = %(conversation_id)s
-        LIMIT 2;
-        ''', {
+    # Update all UserConversation unread count by 1
+    conversation_id = record['conversation_id'].recordID.key
+    conn.execute('''
+        UPDATE %(schema_name)s.user_conversation
+        SET "unread_count" = "unread_count" + 1
+        WHERE "conversation" = %(conversation_id)s
+    ''', {
         'schema_name': AsIs(schema_name),
-        'new_id': new_id,
-        'old_id': old_id,
         'conversation_id': conversation_id
-    }
-    )
-
-    results = {}
-    for row in cur:
-        results[row[0]] = row[1]
-
-    if new_id not in results:
-        raise SkygearChatException("no message found")
-
-    if old_id and results[new_id] < results[old_id]:
-        raise SkygearChatException("the updated message is older")
+    })
 
 
 @skygear.op("chat:get_messages", auth_required=True, user_required=True)
@@ -111,57 +87,3 @@ def get_messages(conversation_id, limit, before_time=None):
             results.append(r)
 
         return {'results': results}
-
-
-@skygear.op("chat:get_unread_message_count",
-            auth_required=True, user_required=True)
-def get_unread_message_count(conversation_id):
-    with db.conn() as conn:
-        cur = conn.execute('''
-            SELECT message_id
-            FROM %(schema_name)s.last_message_read
-            WHERE conversation_id = %(conversation_id)s
-            AND _database_id = %(user_id)s
-            LIMIT 1;
-            ''', {
-            'schema_name': AsIs(schema_name),
-            'conversation_id': conversation_id,
-            'user_id': current_user_id()
-        }
-        )
-
-        results = [row[0] for row in cur]
-
-        if results:
-            message_id = results[0]
-        else:
-            message_id = None
-
-        if message_id:
-            cur = conn.execute('''
-                SELECT COUNT(*)
-                FROM %(schema_name)s.message
-                WHERE _created_at > (
-                    SELECT _created_at
-                    FROM %(schema_name)s.message
-                    WHERE _id = %(message_id)s
-                )
-                AND conversation_id = %(conversation_id)s
-                ''', {
-                'schema_name': AsIs(schema_name),
-                'message_id': message_id,
-                'conversation_id': conversation_id
-            }
-            )
-        else:
-            cur = conn.execute('''
-                SELECT COUNT(*)
-                FROM %(schema_name)s.message
-                WHERE conversation_id = %(conversation_id)s
-                ''', {
-                'schema_name': AsIs(schema_name),
-                'conversation_id': conversation_id
-            }
-            )
-
-    return {'count': [row[0] for row in cur][0]}

--- a/plugin/test/test_handle_message_after_save.py
+++ b/plugin/test/test_handle_message_after_save.py
@@ -15,7 +15,10 @@ class TestHandleMessageAfterSave(unittest.TestCase):
             '_id': 'message/1',
             '_access': None,
             '_ownerID': 'user1',
-            'conversation_id': 'conversation1',
+            'conversation_id': {
+                '$type': 'ref',
+                '$id': 'conversation/1'
+            },
             'body': 'hihi'
         })
 
@@ -24,7 +27,10 @@ class TestHandleMessageAfterSave(unittest.TestCase):
             '_id': 'message/1',
             '_access': None,
             '_ownerID': 'user1',
-            'conversation_id': 'conversation1',
+            'conversation_id': {
+                '$type': 'ref',
+                '$id': 'conversation/1'
+            },
             'body': 'hihi'
         })
 
@@ -33,7 +39,9 @@ class TestHandleMessageAfterSave(unittest.TestCase):
         'participant_ids': ['user1', 'user2']}))
     def test_publish_event_count(
             self, mock_publish_event):
-
+        conn = Mock()
         handle_message_after_save(
-            self.record(), self.original_record(), self.conn)
+            self.record(), self.original_record(), conn)
         self.assertIs(mock_publish_event.call_count, 2)
+        self.assertIs(conn.execute.call_count, 1)
+        self.assertIs(conn.execute.call_args[0][1]['conversation_id'], '1')

--- a/plugin/test/test_user_conversation.py
+++ b/plugin/test/test_user_conversation.py
@@ -37,7 +37,8 @@ class TestUserConversation(unittest.TestCase):
                     '_id':
                     'user_conversation/5e0069ae-1fe3-9680-5512-332b363bbc73',
                     'conversation': {'$id': 'conversation/1', '$type': 'ref'},
-                    'user': {'$id': 'user/userid', '$type': 'ref'}
+                    'user': {'$id': 'user/userid', '$type': 'ref'},
+                    'unread_count': 0
                 }]
             }
         ))


### PR DESCRIPTION
This commit will drop the use of LastMessageRead model. Adopt a write
time update of unread_count at message after save hook. For marking a
last read message of conversation, it will use the after save of
UserConversation to reset the count according to the last read message
created at value

connect #14