### PR TITLE
Get conversations Bug Fix

### DIFF
--- a/chat/conversation.py
+++ b/chat/conversation.py
@@ -111,7 +111,7 @@ class Conversation(ChatRecord):
             participants[key] = []
         predicate = Predicate(conversation__in=list(set(conversation_ids)))
         query_result = database.query(
-                       Query(UserConversation.record_type, predicate=predicate)
+                       Query(UserConversation.record_type, predicate=predicate, limit=None)
                        )
         for row in query_result:
             conversation_id = row['conversation'].recordID.key

--- a/chat/conversation.py
+++ b/chat/conversation.py
@@ -111,7 +111,8 @@ class Conversation(ChatRecord):
             participants[key] = []
         predicate = Predicate(conversation__in=list(set(conversation_ids)))
         query_result = database.query(
-                       Query(UserConversation.record_type, predicate=predicate, limit=None)
+                       Query(UserConversation.record_type, predicate=predicate,
+                             limit=None)
                        )
         for row in query_result:
             conversation_id = row['conversation'].recordID.key


### PR DESCRIPTION
Unset query limit when fetching user_conversation in
__get_participants_and_admins so that all participants can be retrieved

Connects SkygearIO/chat-SDK-Android#124