### PR TITLE
Make get_messages lambda backward compatible

### DIFF
--- a/chat/message_handlers.py
+++ b/chat/message_handlers.py
@@ -33,9 +33,9 @@ def __serialize_message_record(message):
 
 
 def get_messages(conversation_id, limit,
-                 before_time=None, before_message_id=None,
-                 after_time=None, after_message_id=None,
-                 order=None):
+                 before_time=None, order=None,
+                 before_message_id=None,
+                 after_time=None, after_message_id=None):
     if not Conversation.exists(conversation_id):
         raise ConversationNotFoundException()
 

--- a/chat/message_handlers.py
+++ b/chat/message_handlers.py
@@ -33,9 +33,9 @@ def __serialize_message_record(message):
 
 
 def get_messages(conversation_id, limit,
-                 before_time=None, order=None,
-                 before_message_id=None,
-                 after_time=None, after_message_id=None):
+                 before_time=None, before_message_id=None,
+                 after_time=None, after_message_id=None,
+                 order=None):
     if not Conversation.exists(conversation_id):
         raise ConversationNotFoundException()
 
@@ -297,9 +297,9 @@ def register_message_hooks(settings):
 def register_message_lambdas(settings):
     @skygear.op("chat:get_messages", auth_required=True, user_required=True)
     def get_messages_lambda(conversation_id, limit,
-                            before_time=None, before_message_id=None,
-                            after_time=None, after_message_id=None,
-                            order=None):
+                            before_time=None, order=None,
+                            before_message_id=None, after_time=None,
+                            after_message_id=None):
         return get_messages(conversation_id, limit,
                             before_time, before_message_id,
                             after_time, after_message_id,


### PR DESCRIPTION
- Move order paramater argument position to support previous versions SDKs
- Tested with chat-SDK-Android v1.1.2

Connects #196