### PR TITLE
Send message changed event after conversation and user_conversation updated

### DIFF
--- a/chat/message_handlers.py
+++ b/chat/message_handlers.py
@@ -162,7 +162,6 @@ def handle_message_after_save(record, original_record, conn):
     if record.get('deleted', False):
         event_type = 'delete'
 
-    message.notifyParticipants(event_type)
     conversation_id = message.conversation_id
     if original_record is None:
         # Update all UserConversation (except sender) unread count by 1
@@ -205,6 +204,8 @@ def handle_message_after_save(record, original_record, conn):
             'message_id': record.id.key
         })
 
+    # notify participants after conversation and user_conversation updated
+    message.notifyParticipants(event_type)
     conversation = serialize_record(Conversation.fetch_one(conversation_id))
     serialized_message = __serialize_message_record(record)
     participant_ids = conversation['participant_ids']


### PR DESCRIPTION
connect #229 

The original implementation send the new message event in after saved hook already. But after the event is sent, there are sql to updated unread count and conversation last message... This PR update to send the message event after those related records update.